### PR TITLE
fix: explicit conversion to int on augmentation-factor envvar

### DIFF
--- a/rasa/server.py
+++ b/rasa/server.py
@@ -808,7 +808,7 @@ def create_app(
                 fixed_model_name=rjs.get("fixed_model_name"), # bf
                 persist_nlu_training_data=True, # bf
                 additional_arguments={
-                    "augmentation_factor": os.environ.get("AUGMENTATION_FACTOR", 50),
+                    "augmentation_factor": int(os.environ.get("AUGMENTATION_FACTOR", 50)),
                 } # bf
             )
 


### PR DESCRIPTION
Since I couldn't create an issue here, I made this PR, which I think can fix this error:
```
rasa_1          | 2020-06-08 13:40:11 ERROR    rasa.server  - An unexpected error occurred during training. Error: '>' not supported between instances of 'str' and 'int'
rasa_1          | 2020-06-08 13:41:12 DEBUG    rasa.nlu.training_data.loading  - Training data format of '/tmp/tmpwhkwqy4w/nlu_data' is 'rasa_nlu'.
rasa_1          | 2020-06-08 13:41:12 DEBUG    rasa.nlu.training_data.loading  - Training data format of '/tmp/tmp8phvy8zs/stories.md' is 'unk'.
rasa_1          | 2020-06-08 13:41:12 DEBUG    rasa.nlu.training_data.loading  - Training data format of '/tmp/tmp8phvy8zs/nlu/pt.md' is 'unk'.
rasa_1          | 2020-06-08 13:41:12 INFO     rasa.core.policies.ensemble  - MappingPolicy not included in policy ensemble. Default intents 'restart and back will not trigger actions 'action_restart' and 'action_back'.
rasa_1          | 2020-06-08 13:41:12 DEBUG    rasa.core.nlg.generator  - Instantiated NLG to 'TemplatedNaturalLanguageGenerator'.
rasa_1          | 2020-06-08 13:41:12 DEBUG    rasa.core.training.generator  - Generated trackers will be deduplicated based on their unique last 5 states.
rasa_1          | 2020-06-08 13:41:12 DEBUG    rasa.server  - Traceback (most recent call last):
rasa_1          |   File "/opt/venv/lib/python3.6/site-packages/rasa/server.py", line 823, in train
rasa_1          |     None, functools.partial(train_model, **info)
rasa_1          |   File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
rasa_1          |     result = self.fn(*self.args, **self.kwargs)
rasa_1          |   File "/opt/venv/lib/python3.6/site-packages/rasa/train.py", line 50, in train
rasa_1          |     additional_arguments=additional_arguments,
rasa_1          |   File "uvloop/loop.pyx", line 1456, in uvloop.loop.Loop.run_until_complete
rasa_1          |   File "/opt/venv/lib/python3.6/site-packages/rasa/train.py", line 106, in train_async
rasa_1          |     additional_arguments,
rasa_1          |   File "/opt/venv/lib/python3.6/site-packages/rasa/train.py", line 199, in _train_async_internal
rasa_1          |     additional_arguments=additional_arguments,
rasa_1          |   File "/opt/venv/lib/python3.6/site-packages/rasa/train.py", line 234, in _do_training
rasa_1          |     additional_arguments=additional_arguments,
rasa_1          |   File "/opt/venv/lib/python3.6/site-packages/rasa/train.py", line 373, in _train_core_with_validated_data
rasa_1          |     additional_arguments=additional_arguments,
rasa_1          |   File "/opt/venv/lib/python3.6/site-packages/rasa/core/train.py", line 64, in train
rasa_1          |     training_resource, exclusion_percentage=exclusion_percentage, **data_load_args
rasa_1          |   File "/opt/venv/lib/python3.6/site-packages/rasa/core/agent.py", line 676, in load_data
rasa_1          |     exclusion_percentage=exclusion_percentage,
rasa_1          |   File "/opt/venv/lib/python3.6/site-packages/rasa/core/training/__init__.py", line 69, in load_data
rasa_1          |     return g.generate()
rasa_1          |   File "/opt/venv/lib/python3.6/site-packages/rasa/core/training/generator.py", line 221, in generate
rasa_1          |     min_num_aug_phases = 3 if self.config.augmentation_factor > 0 else 0
rasa_1          | TypeError: '>' not supported between instances of 'str' and 'int'
rasa_1          | 
```

According to the documentation (https://docs.python.org/3.7/library/os.html#os.environ), os.environ is a "mapping object representing the string environment", this means that its values are strings and os.environ.get is returning a string, without this explicit conversion some comparsion errors are present (comparing str and int, for instance).

**Proposed changes**:
- Adds a explicit  converstion from str to int when reading the AUGMENTATION_FACTOR env var.

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/master/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
