### PR TITLE
refactor: add template name to response metdata

### DIFF
--- a/rasa_addons/core/nlg/bftemplate.py
+++ b/rasa_addons/core/nlg/bftemplate.py
@@ -97,6 +97,7 @@ class BotfrontTemplatedNaturalLanguageGenerator(NaturalLanguageGenerator):
         metadata = message.pop("metadata", {}) or {}
         for key in metadata:
             message[key] = metadata[key]
+        message["template_name"] = template_name
 
         return message
 

--- a/rasa_addons/core/nlg/graphql.py
+++ b/rasa_addons/core/nlg/graphql.py
@@ -173,6 +173,7 @@ class GraphQLNaturalLanguageGenerator(NaturalLanguageGenerator):
                 metadata = response.pop("metadata", {}) or {}
                 for key in metadata:
                     response[key] = metadata[key]
+                response["template_name"] = template_name
 
                 keys_to_interpolate = [
                     "text",


### PR DESCRIPTION
template name was missing for response from forms causing bugs in test cases