### PR TITLE
fix: bot regression tests always use fallback lang

### DIFF
--- a/rasa_addons/core/channels/bot_regression_test.py
+++ b/rasa_addons/core/channels/bot_regression_test.py
@@ -48,7 +48,7 @@ class BotRegressionTestInput(RestInput):
         for step in steps:
             if "user" in step:
                 text = step.get("user")
-                metadata = {"lang": language}
+                metadata = {"language": language}
                 try:
                     await on_new_message(
                         UserMessage(


### PR DESCRIPTION
botfront regression tests in a language that wasn't the default language would be interpreted as if they were in the default language.