### PR TITLE
feat: change projectId in the put method

### DIFF
--- a/rasa_addons/core/tracker_stores/botfront.py
+++ b/rasa_addons/core/tracker_stores/botfront.py
@@ -73,7 +73,7 @@ def _start_sweeper(tracker_store, break_time):
 class BotfrontTrackerStore(TrackerStore):
     def __init__(self, domain, host, **kwargs):
 
-        self.project_id = os.environ.get("BF_PROJECT_ID")
+        self.project_id = kwargs.get("project_id")
         self.tracker_persist_time = kwargs.get("tracker_persist_time", 3600)
         self.test_tracker_persist_time = kwargs.get("test_tracker_persist_time", 240)
         self.max_events = kwargs.get("max_events", 100)


### PR DESCRIPTION
I have added this code but not able to build it due to an error in the docker image. 

To summarize the change : 

- Adding the endpoint for the selected project to the `put` method in `server.py` 
- When the agent loaded it will cascade the project_id to `BotfrontTrackerStore`